### PR TITLE
CB-12517 : updated pkgjson displayname and name

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,9 +287,19 @@ module.exports = function(dir, optionalId, optionalName, cfg, extEvents) {
         // Update package.json name and version fields
         if (fs.existsSync(pkgjsonPath)) {
             var pkgjson = require(pkgjsonPath);
+
+            // Pkjson.displayName should equal config's name.
             if (cfg.name) {
-                pkgjson.name = cfg.name.toLowerCase();
+                pkgjson.displayName = cfg.name;
             }
+            // Pkjson.name should equal config's id.
+            if(cfg.id) {
+                pkgjson.name = cfg.id.toLowerCase();
+            } else if(!cfg.id) {
+                // Use default name.
+                pkgjson.name = 'helloworld';
+            }
+
             pkgjson.version = '1.0.0';
             fs.writeFileSync(pkgjsonPath, JSON.stringify(pkgjson, null, 4), 'utf8');
         }

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -175,7 +175,8 @@ describe('create end-to-end', function() {
 
         // Check that we got package.json (the correct one)
         var pkjson = require(path.join(project, 'package.json'));
-        expect(pkjson.name).toEqual(appName.toLowerCase());
+        // Pkjson.displayName should equal config's name.
+        expect(pkjson.displayName).toEqual(appName);
         expect(pkjson.valid).toEqual('true');
 
         // Check that we got the right config.xml
@@ -418,7 +419,8 @@ describe('create end-to-end', function() {
 
                     // Check that we got package.json (the correct one) and it was changed
                     var pkjson = require(path.join(project, 'package.json'));
-                    expect(pkjson.name).toEqual(appName.toLowerCase());
+                    // Pkjson.name should equal config's id.
+                    expect(pkjson.name).toEqual(appId.toLowerCase());
                     expect(pkjson.valid).toEqual('true');
                 }
                 var config = {


### PR DESCRIPTION
package.json's displayName should equal config.xml's name and package.json's name should equal config.xml's id

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Package.json's displayName should equal config.xml's name and package.json's name should equal config.xml's id. Tests have been updated to reflect changes.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
