### PR TITLE
CB-12397 fix .gitignore for plugins & platforms (cordova-create part)

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,17 @@ module.exports = function (dir, optionalId, optionalName, cfg, extEvents) {
                 fs.mkdirSync(dir);
             }
 
+            // CB-12397 add .gitignore for plugins & platforms
+            // to generated app
+            // (use stock .npmignore for ignore file)
+            // NOTE: This is a workaround solution for the existing
+            // npm .gitignore/.npmignore behavior discussed in:
+            // npm/npm#1862
+            // npm/npm#3763
+            // npm/npm#7252
+            const ignoreStockPath =
+                path.join(require('cordova-app-hello-world').dirname, '.npmignore');
+
             try {
                 // Copy files from template to project
                 if (cfg.lib.www.template) {
@@ -263,6 +274,16 @@ module.exports = function (dir, optionalId, optionalName, cfg, extEvents) {
 
                 pkgjson.version = DEFAULT_VERSION;
                 fs.writeFileSync(pkgjsonPath, JSON.stringify(pkgjson, null, 4), 'utf8');
+
+                // XXX TODO USE fs-extra function instead,
+                // XXX WAITING FOR apache/cordova-create#14 to be merged
+                // CB-12397 add .gitignore for plugins & platforms
+                // to generated app
+                // XXX GONE:
+                shell.cp(ignoreStockPath, path.join(dir, '.gitignore'));
+                /* ** XXX TODO:
+                fs.copySync(ignoreStockPath, path.join(dir, '.gitignore'));
+                // */
             }
 
             // Create basic project structure.

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -57,80 +57,130 @@ describe('cordova create checks for valid-identifier', function () {
 
 describe('create end-to-end', function () {
 
-    function checkProject () {
+    function checkProjectCommonArtifacts () {
         // Check if top level dirs exist.
         var dirs = ['hooks', 'platforms', 'plugins', 'www'];
         dirs.forEach(function (d) {
             expect(path.join(project, d)).toExist();
         });
 
+        // Check that README.md exists inside of hooks
         expect(path.join(project, 'hooks', 'README.md')).toExist();
 
-        // Check if www files exist.
+        // Check that index.html exists inside of www
         expect(path.join(project, 'www', 'index.html')).toExist();
+
+        // Check if config.xml exists.
+        expect(path.join(project, 'config.xml')).toExist();
+
+        // index.html, index.js and template subdir folder
+        // should not exist in top level
+        // (inner files should be copied to the project top level folder)
+        expect(path.join(project, 'index.html')).not.toExist();
+        expect(path.join(project, 'index.js')).not.toExist();
+        expect(path.join(project, 'template')).not.toExist();
+
+        // Check that .gitignore does not exist inside of www
+        expect(path.join(project, 'www', '.gitignore')).not.toExist();
+
+        // Check that .npmignore does not exist inside of www
+        expect(path.join(project, 'www', '.npmignore')).not.toExist();
+
+        // Check that config.xml does not exist inside of www
+        expect(path.join(project, 'www', 'config.xml')).not.toExist();
+
+        // Check that no package.json exists inside of www
+        expect(path.join(project, 'www', 'package.json')).not.toExist();
 
         // Check that config.xml was updated.
         var configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.packageName()).toEqual(appId);
-
-        // TODO (kamrik): check somehow that we got the right config.xml from the fixture and not some place else.
-        // expect(configXml.name()).toEqual('TestBase');
+        expect(configXml.version()).toEqual('1.0.0');
+        // Check that we got the right config.xml from the fixture and not some place else.
+        expect(configXml.name()).toEqual('TestBase');
     }
 
-    function checkConfigXml () {
-        // Check if top level dirs exist.
-        var dirs = ['hooks', 'platforms', 'plugins', 'www'];
-        dirs.forEach(function (d) {
-            expect(path.join(project, d)).toExist();
-        });
-        expect(path.join(project, 'hooks', 'README.md')).toExist();
+    function checkProjectArtifactsWithConfigFromTemplate () {
+        checkProjectCommonArtifacts();
 
-        // index.js and template subdir folder should not exist (inner files should be copied to the project folder)
-        expect(path.join(project, 'index.js')).not.toExist();
-        expect(path.join(project, 'template')).not.toExist();
+        // Check that standard js artifact does not exist
+        expect(path.join(project, 'www', 'js')).not.toExist();
+        expect(path.join(project, 'www', 'js', 'index.js')).not.toExist();
 
-        // Check if www files exist.
-        expect(path.join(project, 'www', 'index.html')).toExist();
-        var configXml = new ConfigParser(path.join(project, 'config.xml'));
-        expect(configXml.packageName()).toEqual(appId);
-        expect(configXml.version()).toEqual('1.0.0');
-
-        // Check that config.xml does not exist inside of www
-        expect(path.join(project, 'www', 'config.xml')).not.toExist();
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .npmignore does not exist
+        expect(path.join(project, '.npmignore')).not.toExist();
 
         // Check that we got no package.json
         expect(path.join(project, 'package.json')).not.toExist();
 
         // Check that we got the right config.xml from the template and not stock
+        const configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.description()).toEqual('this is the correct config.xml');
     }
 
-    function checkSubDir () {
-        // Check if top level dirs exist.
-        var dirs = ['hooks', 'platforms', 'plugins', 'www'];
-        dirs.forEach(function (d) {
-            expect(path.join(project, d)).toExist();
-        });
-        expect(path.join(project, 'hooks', 'README.md')).toExist();
+    function checkProjectArtifactsWithNoPackageFromTemplate () {
+        checkProjectCommonArtifacts();
 
-        // index.js and template subdir folder should not exist (inner files should be copied to the project folder)
-        expect(path.join(project, 'index.js')).not.toExist();
-        expect(path.join(project, 'template')).not.toExist();
+        // Check that standard js artifact does not exist
+        expect(path.join(project, 'www', 'js')).not.toExist();
+        expect(path.join(project, 'www', 'js', 'index.js')).not.toExist();
+
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .npmignore does not exist
+        expect(path.join(project, '.npmignore')).not.toExist();
+
+        // Check that we got no package.json
+        expect(path.join(project, 'package.json')).not.toExist();
+    }
+
+    function checkProjectArtifactsWithPackageFromTemplate () {
+        checkProjectCommonArtifacts();
+
+        // Check that standard js artifact exists
+        expect(path.join(project, 'www', 'js')).toExist();
+        expect(path.join(project, 'www', 'js', 'index.js')).toExist();
+
+        // Check if package.json exists.
+        expect(path.join(project, 'package.json')).toExist();
+
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .npmignore exists
+        expect(path.join(project, '.npmignore')).toExist();
+
+        // Check that we got package.json (the correct one)
+        var pkjson = requireFresh(path.join(project, 'package.json'));
+        // Pkjson.displayName should equal config's name.
+        expect(pkjson.displayName).toEqual('TestBase');
+    }
+
+    function checkProjectArtifactsWithPackageFromSubDir () {
+        checkProjectCommonArtifacts();
+
+        // Check that standard js artifact does not exist
+        expect(path.join(project, 'www', 'js')).not.toExist();
+        expect(path.join(project, 'www', 'js', 'index.js')).not.toExist();
+
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .npmignore does not exist
+        expect(path.join(project, '.npmignore')).not.toExist();
 
         // Check if config files exist.
         expect(path.join(project, 'www', 'index.html')).toExist();
 
-        // Check that config.xml was updated.
-        var configXml = new ConfigParser(path.join(project, 'config.xml'));
-        expect(configXml.packageName()).toEqual(appId);
-        expect(configXml.version()).toEqual('1.0.0');
         // Check that we got package.json (the correct one)
         var pkjson = requireFresh(path.join(project, 'package.json'));
+
         // Pkjson.displayName should equal config's name.
         expect(pkjson.displayName).toEqual(appName);
         expect(pkjson.valid).toEqual('true');
 
         // Check that we got the right config.xml
+        const configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.description()).toEqual('this is the correct config.xml');
     }
 
@@ -138,7 +188,7 @@ describe('create end-to-end', function () {
         // Create a real project with no template
         // use default cordova-app-hello-world app
         return create(project, appId, appName, {}, events)
-            .then(checkProject)
+            .then(checkProjectArtifactsWithPackageFromTemplate)
             .then(function () {
                 var pkgJson = requireFresh(path.join(project, 'package.json'));
                 // confirm default hello world app copies over package.json and it matched appId
@@ -161,7 +211,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url);
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with NPM package', function () {
@@ -179,7 +229,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url);
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with NPM package and explicitly fetch latest if no version is given', function () {
@@ -198,7 +248,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url + '@latest');
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with template not having a package.json at toplevel', function () {
@@ -211,7 +261,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject)
+            .then(checkProjectArtifactsWithNoPackageFromTemplate)
             .then(function () {
                 // Check that we got the right config.xml
                 var configXml = new ConfigParser(path.join(project, 'config.xml'));
@@ -229,7 +279,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithNoPackageFromTemplate);
     });
 
     it('should successfully run with template having package.json, and subdirectory, and no package.json in subdirectory', function () {
@@ -242,7 +292,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithNoPackageFromTemplate);
     });
 
     it('should successfully run with template having package.json, and subdirectory, and package.json in subdirectory', function () {
@@ -255,7 +305,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkSubDir);
+            .then(checkProjectArtifactsWithPackageFromSubDir);
     });
 
     it('should successfully run config.xml in the www folder and move it outside', function () {
@@ -268,7 +318,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkConfigXml);
+            .then(checkProjectArtifactsWithConfigFromTemplate);
     });
 
     it('should successfully run with www folder as the template', function () {
@@ -281,13 +331,20 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkConfigXml);
+            .then(checkProjectArtifactsWithConfigFromTemplate)
+            .then(() => {
+                // Additional check that we have the fixture www,
+                // not one from stock the app
+                expect(path.join(project, 'www', 'fixture-marker-page.html')).toExist();
+                expect(path.join(project, 'www', 'subdir')).toExist();
+                expect(path.join(project, 'www', 'subdir', 'sub-fixture-marker-page.html')).toExist();
+            });
     });
 
     it('should successfully run with existing, empty destination', function () {
         shell.mkdir('-p', project);
         return create(project, appId, appName, {}, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     describe('when --link-to is provided', function () {
@@ -315,6 +372,7 @@ describe('create end-to-end', function () {
 
                 // Check www/config exists
                 expect(path.join(project, 'www', 'config.xml')).toExist();
+
                 // Check www/config.xml was not updated.
                 var configXml = new ConfigParser(path.join(project, 'www', 'config.xml'));
                 expect(configXml.packageName()).toEqual('io.cordova.hellocordova');
@@ -323,6 +381,7 @@ describe('create end-to-end', function () {
 
                 // Check that config.xml was copied to project/config.xml
                 expect(path.join(project, 'config.xml')).toExist();
+
                 configXml = new ConfigParser(path.join(project, 'config.xml'));
                 expect(configXml.description()).toEqual('this is the correct config.xml');
                 // Check project/config.xml was updated.

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -146,8 +146,8 @@ describe('create end-to-end', function () {
         // Check if package.json exists.
         expect(path.join(project, 'package.json')).toExist();
 
-        // [CB-12397] Check that .gitignore does not exist
-        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .gitignore exists
+        expect(path.join(project, '.gitignore')).toExist();
         // [CB-12397] Check that .npmignore exists
         expect(path.join(project, '.npmignore')).toExist();
 
@@ -164,8 +164,8 @@ describe('create end-to-end', function () {
         expect(path.join(project, 'www', 'js')).not.toExist();
         expect(path.join(project, 'www', 'js', 'index.js')).not.toExist();
 
-        // [CB-12397] Check that .gitignore does not exist
-        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .gitignore exists
+        expect(path.join(project, '.gitignore')).toExist();
         // [CB-12397] Check that .npmignore does not exist
         expect(path.join(project, '.npmignore')).not.toExist();
 

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -85,9 +85,9 @@ beforeEach(function () {
                     result.pass = fs.existsSync(testPath);
 
                     if (result.pass) {
-                        result.message = 'Expected file ' + testPath + ' to exist.';
-                    } else {
                         result.message = 'Expected file ' + testPath + ' to not exist.';
+                    } else {
+                        result.message = 'Expected file ' + testPath + ' to exist.';
                     }
 
                     return result;

--- a/spec/templates/config_in_www/www/fixture-marker-page.html
+++ b/spec/templates/config_in_www/www/fixture-marker-page.html
@@ -1,0 +1,1 @@
+<h1>Fixture marker page</h1>

--- a/spec/templates/config_in_www/www/subdir/sub-fixture-marker-page.html
+++ b/spec/templates/config_in_www/www/subdir/sub-fixture-marker-page.html
@@ -1,0 +1,1 @@
+<h1>Sub-fixture marker page</h1>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Workaround for [Apache Cordova CB-12397](https://issues.apache.org/jira/browse/CB-12397): include .gitignore from `template_src` subdirectory of `cordova-app-hello-world`, needed due to the npm .gitignore/.npmignore behavior discussed in:
- npm/npm#1862
- npm/npm#3763
- npm/npm#7252

NOTE: Another part of the fix for  [Apache Cordova CB-12397](https://issues.apache.org/jira/browse/CB-12397) is in <https://github.com/brodybits/cordova-app-hello-world/tree/cb-12397>, to be raised after this PR.

Additional commits:
- cleanup: remove trailing whitespace
- general updates to test suite

### What testing has been done on this change?

#### Unit test

Test suite updated to verify that `.gitignore` is included in the generated app when the standard `cordova-app-hello-world` template is used.

#### Cordova CLI test

- Using `cordova-cli` test version in <https://github.com/brodybits/cordova-cli/tree/cb-12397-devtest1> which uses local test installation of `cordova-lib` from <https://github.com/brodybits/cordova-lib/tree/cb-12397-devtest1> due to limitations discussed in npm/npm#2974.
- `cordova-lib` in <https://github.com/brodybits/cordova-lib/tree/cb-12397-devtest1> references `cordova-create` in <https://github.com/brodybits/cordova-create/tree/cb-12397-devtest1> which includes this fix.
- `cordova-create` in <https://github.com/brodybits/cordova-create/tree/cb-12397-devtest1> references `cordova-app-hello-world` in <https://github.com/brodybits/cordova-app-hello-world/tree/cb-12397-devtest1> which includes the `cordova-app-hello-world` fix in <https://github.com/brodybits/cordova-app-hello-world/tree/cb-12397>.

**Testing with results and other output on Windows:**

```
C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ npm install -g https://github.com/brodybits/cordova-cli#cb-12397-devtest1
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
C:\Users\Chris\nvs\node\7.10.0\x64\cordova -> C:\Users\Chris\nvs\node\7.10.0\x64\node_modules\cordova\bin\cordova
C:\Users\Chris\nvs\node\7.10.0\x64
`-- cordova@7.0.2-cb-12397-devtest1  (git+https://github.com/brodybits/cordova-cli.git#9f4648d5565b098434187aa3da251beca8d68dae)
[...]
C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ cordova --version
7.0.2-cb-12397-devtest1

C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ cordova create cb-12397-testapp1
Creating a new cordova project.

C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ ls -a !$
History expansion: ls -a cb-12397-testapp1
./  ../  .gitignore  .npmignore  config.xml  hooks/  package.json  platforms/  plugins/  res/  www/

C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ cat cb-12397-testapp1\.gitignore
# macOS
.DS_Store

# Generated by Cordova
plugins
platforms

C:\Users\Chris\Documents\chris-work\cb-12397-dev
λ
```

`.gitignore` is now present in the generated app, with `plugins` and `platforms` as needed

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

