### PR TITLE
Introduce fs-extra usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cordova-app-hello-world": "^3.11.0",
     "cordova-common": "^2.2.0",
     "cordova-fetch": "^1.3.0",
+    "fs-extra": "^6.0.1",
     "import-fresh": "^2.0.0",
     "is-url": "^1.2.4",
     "q": "^1.5.1",

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -17,10 +17,10 @@
     under the License.
 */
 
-var fs = require('fs');
+const fs = require('fs-extra');
+
 var path = require('path');
 
-var shell = require('shelljs');
 var requireFresh = require('import-fresh');
 
 var create = require('..');
@@ -35,12 +35,12 @@ var project = path.join(tmpDir, appName);
 
 // Setup and teardown test dirs
 beforeEach(function () {
-    shell.rm('-rf', project);
-    shell.mkdir('-p', tmpDir);
+    fs.removeSync(project);
+    fs.ensureDirSync(tmpDir);
 });
 afterEach(function () {
     process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
-    shell.rm('-rf', tmpDir);
+    fs.removeSync(tmpDir);
 });
 
 describe('cordova create checks for valid-identifier', function () {
@@ -285,7 +285,7 @@ describe('create end-to-end', function () {
     });
 
     it('should successfully run with existing, empty destination', function () {
-        shell.mkdir('-p', project);
+        fs.ensureDirSync(project);
         return create(project, appId, appName, {}, events)
             .then(checkProject);
     });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Introduce usage of `fs-extra` and isolate `shelljs` usage, as a first step towards completely dropping `shelljs` dependency as discussed in <https://github.com/apache/cordova-common/pull/21#issuecomment-390712055> and <https://github.com/apache/cordova-discuss/issues/69#issuecomment-392782951>

### What testing has been done on this change?

- Changes to `index.js` pass existing `spec` suite

### Checklist
- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~

### FUTURE TODO

As discussed in <https://github.com/apache/cordova-common/pull/21#issuecomment-390712055> and <https://github.com/apache/cordova-discuss/issues/69#issuecomment-392782951> it is desired to complete drop dependency on `shelljs`. My first attempt to replace `shell.cp` call with `fs-extra` call did not pass the existing test suite. If someone else can resolve this issue I would be happy to amend this PR or maybe even drop it in favor of another solution.