### PR TITLE
Fix error messages for toExist matcher

### DIFF
--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -85,9 +85,9 @@ beforeEach(function () {
                     result.pass = fs.existsSync(testPath);
 
                     if (result.pass) {
-                        result.message = 'Expected file ' + testPath + ' to exist.';
-                    } else {
                         result.message = 'Expected file ' + testPath + ' to not exist.';
+                    } else {
+                        result.message = 'Expected file ' + testPath + ' to exist.';
                     }
 
                     return result;


### PR DESCRIPTION
The message in case of failure was negated.