### PR TITLE
Updated Apache License Version

### DIFF
--- a/spec/templates/withsubdirectory_package_json/template/package.json
+++ b/spec/templates/withsubdirectory_package_json/template/package.json
@@ -6,6 +6,6 @@
     "type": "git",
     "url": "https://github.com/apache/cordova-app-hello-world.git"
   },
-  "license": "Apache-1.0",
+  "license": "Apache-2.0",
   "valid": "true"
 }


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Updates the license of a test spec's `package.json` from Apache-1.0 to Apache-2.0.

**Changes**
`"license": "Apache-1.0",` becomes `"license": "Apache-2.0",`

### What testing has been done on this change?
- `npm i`
- `npm run jasmine`