### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "email": "dev@cordova.apache.org"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {
     "cordova-app-hello-world": "^4.0.0",


### PR DESCRIPTION
### Motivation and Context

Next major release, `cordova-create@3.x` will no longer test or require code to be backwards compatible with node 6 and 8.

### Description

- Removes node 6 and 8 from testing and `package.json`.
- Updated minimum supported node version.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
