### PR TITLE
Fix isRemoteUri

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const fs = require('fs-extra');
 var path = require('path');
 
 var tmp = require('tmp');
-var isUrl = require('is-url');
+const npa = require('npm-package-arg');
 var isObject = require('isobject');
 var pathIsInside = require('path-is-inside');
 var requireFresh = require('import-fresh');
@@ -168,5 +168,5 @@ function getSelfDestructingTempDir () {
 }
 
 function isRemoteUri (uri) {
-    return isUrl(uri) || uri.includes('@') || !fs.existsSync(uri);
+    return npa(uri).type !== 'directory';
 }

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function cordovaCreate (dest, opts = {}) {
             emit('log', 'Creating a new cordova project.');
 
             // Use cordova-fetch to obtain npm or git templates
-            if (isRemoteUri(opts.template)) {
+            if (needsToBeFetched(opts.template)) {
                 var target = opts.template;
                 emit('verbose', 'Using cordova-fetch for ' + target);
                 return fetch(target, getSelfDestructingTempDir(), {});
@@ -167,6 +167,6 @@ function getSelfDestructingTempDir () {
     }).name;
 }
 
-function isRemoteUri (uri) {
+function needsToBeFetched (uri) {
     return npa(uri).type !== 'directory';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1438,11 +1438,6 @@
         "has-symbols": "^1.0.0"
       }
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "cordova-fetch": "^2.0.0",
     "fs-extra": "^8.1.0",
     "import-fresh": "^3.1.0",
-    "is-url": "^1.2.4",
     "isobject": "^4.0.0",
+    "npm-package-arg": "^6.1.1",
     "path-is-inside": "^1.0.2",
     "tmp": "^0.1.0",
     "valid-identifier": "0.0.2"

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -229,28 +229,22 @@ describe('when shit happens', function () {
     });
 });
 
-describe('cordova create isRemoteUri', () => {
-    let isRemoteUri;
+describe('cordova create needsToBeFetched', () => {
+    let needsToBeFetched;
 
     beforeEach(() => {
-        isRemoteUri = rewire('..').__get__('isRemoteUri');
+        needsToBeFetched = rewire('..').__get__('needsToBeFetched');
     });
 
     it('should recognize URLs as remote', () => {
-        expect(isRemoteUri('https://example.com/pkg/foo')).toBe(true);
+        expect(needsToBeFetched('https://example.com/pkg/foo')).toBe(true);
     });
 
     it('should recognize package@version as remote', () => {
-        const spec = 'foo@1';
-        spyOn(fs, 'existsSync').withArgs(spec).and.returnValue(false);
-
-        expect(isRemoteUri(spec)).toBe(true);
+        expect(needsToBeFetched('foo@1')).toBe(true);
     });
 
     it('should not detect paths as remote only because they include an @', () => {
-        const spec = '../foo@1';
-        spyOn(fs, 'existsSync').withArgs(spec).and.returnValue(true);
-
-        expect(isRemoteUri(spec)).toBe(false);
+        expect(needsToBeFetched('../foo@1')).toBe(false);
     });
 });

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -18,6 +18,7 @@
 */
 
 const fs = require('fs-extra');
+const rewire = require('rewire');
 
 var path = require('path');
 
@@ -225,5 +226,31 @@ describe('when shit happens', function () {
             create(project, opts),
             new CordovaError('not a valid template')
         );
+    });
+});
+
+describe('cordova create isRemoteUri', () => {
+    let isRemoteUri;
+
+    beforeEach(() => {
+        isRemoteUri = rewire('..').__get__('isRemoteUri');
+    });
+
+    it('should recognize URLs as remote', () => {
+        expect(isRemoteUri('https://example.com/pkg/foo')).toBe(true);
+    });
+
+    it('should recognize package@version as remote', () => {
+        const spec = 'foo@1';
+        spyOn(fs, 'existsSync').withArgs(spec).and.returnValue(false);
+
+        expect(isRemoteUri(spec)).toBe(true);
+    });
+
+    it('should not detect paths as remote only because they include an @', () => {
+        const spec = '../foo@1';
+        spyOn(fs, 'existsSync').withArgs(spec).and.returnValue(true);
+
+        expect(isRemoteUri(spec)).toBe(false);
     });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #34 


### Description
<!-- Describe your changes in detail -->
We use `npm-package-arg` to determine to what a spec refers. That's the package used by `npm` for spec parsing.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added unit tests before the change, including one failing for #34. Tests all pass after change.
