### PR TITLE
chore: eslint config cleanup

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 root: true
 extends: '@cordova/eslint-config/node'
+
+overrides:
+  - files: [spec/**/*.js]
+    extends: '@cordova/eslint-config/node-tests'

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,2 +1,0 @@
-root: true
-extends: '@cordova/eslint-config/node-tests'


### PR DESCRIPTION
### Motivation and Context

Consolidate configs into one file

### Description

* Removed `.eslintrc.yml` from testing directory and added configs to parent configs as override.
* Added missing Apache Header License

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
