### PR TITLE
chore: bump npm-package-arg and jasmine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "globby": "^11.1.0",
         "import-fresh": "^3.3.1",
         "isobject": "^4.0.0",
-        "npm-package-arg": "^13.0.0",
+        "npm-package-arg": "^13.0.2",
         "path-is-inside": "^1.0.2",
         "tmp": "^0.2.5",
         "valid-identifier": "0.0.2"
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@cordova/eslint-config": "^6.0.0",
         "c8": "^10.1.3",
-        "jasmine": "^5.10.0",
+        "jasmine": "^5.13.0",
         "rewire": "^9.0.1"
       },
       "engines": {
@@ -3790,23 +3790,23 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.10.0.tgz",
-      "integrity": "sha512-v4FojO8cXQdx15mJXovGhjJOvyIcVf7AC+H0ZahnfLk52vUbwuLxjVgbikc95yLmgwKQsFT47/FGQ3dOrWVxtQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.13.0.tgz",
+      "integrity": "sha512-oLCXIhEb5e0zzjn9GyuvcuisvLBwUjmgz7a0RNGWKwQtJCDld4m+vwKUpAIJVLB5vbmQFdtKhT86/tIZlJ5gYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.2.2",
-        "jasmine-core": "~5.10.0"
+        "jasmine-core": "~5.13.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.10.0.tgz",
-      "integrity": "sha512-MrChbWV5LBo+EaeKwTM1eZ6oYSz1brvFExnRafraEkJkbJ9evbUxABhnIgGQimhpMxhg+BD6QmOvb/e3NXsNdg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.13.0.tgz",
+      "integrity": "sha512-vsYjfh7lyqvZX5QgqKc4YH8phs7g96Z8bsdIFNEU3VqXhlHaq+vov/Fgn/sr6MiUczdZkyXRC3TX369Ll4Nzbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4300,15 +4300,15 @@
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.0.tgz",
-      "integrity": "sha512-+t2etZAGcB7TbbLHfDwooV9ppB2LhhcT6A+L9cahsf9mEUAoQ6CktLEVvEnpD0N5CkX7zJqnPGaFtoQDy9EkHQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4333,6 +4333,24 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-packlist": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "globby": "^11.1.0",
     "import-fresh": "^3.3.1",
     "isobject": "^4.0.0",
-    "npm-package-arg": "^13.0.0",
+    "npm-package-arg": "^13.0.2",
     "path-is-inside": "^1.0.2",
     "tmp": "^0.2.5",
     "valid-identifier": "0.0.2"
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@cordova/eslint-config": "^6.0.0",
     "c8": "^10.1.3",
-    "jasmine": "^5.10.0",
+    "jasmine": "^5.13.0",
     "rewire": "^9.0.1"
   },
   "scripts": {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
N/A (Node.js module, not platform-specific)


### Motivation and Context

This change updates outdated dependencies to their latest compatible patch/minor versions.
Keeping dependencies up to date improves stability, security, and maintainability.


### Description

Updated the following dependencies:
- npm-package-arg from 13.0.0 to 13.0.2
- jasmine from 5.10.0 to 5.13.0

No functional code changes were made.


### Testing
Ran the full test suite locally using:
npm test
All tests passed successfully.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
